### PR TITLE
Use associated array keys when defining TCA field 'CType' items.

### DIFF
--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content.php
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content.php
@@ -9,11 +9,13 @@ defined('TYPO3') or die();
     'CType',
     [
         // title
-        'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_newcontentelement_title',
+        'label' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_newcontentelement_title',
         // plugin signature: extkey_identifier
-        'myextension_newcontentelement',
+        'value' => 'myextension_newcontentelement',
         // icon identifier
-        'content-text',
+        'icon' => 'content-text',
+        // group
+        'group' => 'common',
     ],
     'textmedia',
     'after'


### PR DESCRIPTION
Avoid TCA Migration warning: "The TCA field 'CType' of table 'tt_content' uses the legacy way of defining 'items'. Please switch to associated array keys: label, value, icon, group, description."