### PR TITLE
[BUGFIX] Use consistent variable name in FlexFormProcessor example

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -521,7 +521,7 @@ If you defined your :typoscript:`FLUIDTEMPLATE` in TypoScript, you can assign si
 
 In order to have all FlexForm fields available, you can use the FlexFormProcessor. See also
 :ref:`FlexFormProcessor in the TypoScript Reference<t3tsref:FlexFormProcessor>`.
-This example would make your FlexForm data available as Fluid variable :html:`{flexform}`:
+This example would make your FlexForm data available as Fluid variable :html:`{myOutputVariable}`:
 
 .. code-block:: typoscript
 


### PR DESCRIPTION
Followup to PR #4574